### PR TITLE
Removing preload and prefetch links that inject scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ var stripJs = function(htmlContent) {
    for (var i = 0; i < formElements.length; i++) {
       domElement.removeAttr('action');
    }
+   
+   // Remove link elements with 'as' attribute equalling to 'script'
+   $('link[as="script"]').remove();
 
    return $.html();
 }

--- a/test/test.js
+++ b/test/test.js
@@ -55,6 +55,10 @@ assert(stripJs('<img src="cid:foo">') ==
    '<img src="cid:foo">');
 assert(stripJs('<img src="foo:bar">') ==
    '<img>');
+   
+// Scripts cannot be injected through links
+assert.equal(stripJs('<link rel="preload" href="https://adservice.google.com.sg/adsid/' +
+  'integrator.js?domain=sourceforge.net" as="script">'), '');
 
 // TODO: More test cases?
 


### PR DESCRIPTION
Currently script injecting is still possible using preload:

```
<link rel="preload" href="https://adservice.google.com.sg/adsid/integrator.js?domain=sourceforge.net" as="script">
```

This PR fixes this with a test.