### PR TITLE
preserve doctypes (updated tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ var html = fs.readFileSync('./webpage.html').toString();
 var safeHtml = stripJs(html); // It returns plain HTML text
 ```
 
+If you need to preserve doctypes, use `var safeHtml = stripJs(html, { preserveDoctypes: true });`. `preserveDoctypes` defaults to false.
+
 For command line usage, install it globally. It reads the input HTML from its stdin and outputs the result to stdout.
 ```bash
 strip-js < input.html

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 var cheerio = require('cheerio');
 var sanitizeHtml = require('sanitize-html');
+var defaultOpts = { preserveDoctypes: false };
+var doctypeRegex = /^\s*<!DOCTYPE .*?>/i;
 
-var stripJs = function(htmlContent) {
+var stripJs = function(htmlContent, opts) {
+   opts = Object.assign({}, defaultOpts, opts);
+  
    // Basic input validation:
    if ((htmlContent == undefined) || (htmlContent == null) ||
        (typeof htmlContent != 'string')) {
@@ -9,8 +13,11 @@ var stripJs = function(htmlContent) {
    }
 
    // Sanitize the HTML first:
-   var doctypeRegex = /<!DOCTYPE .*?>/i;
-   var doctypes = htmlContent.match(doctypeRegex);
+   var doctypes;
+   if (opts.preserveDoctypes) {
+      doctypes = htmlContent.match(doctypeRegex);
+   }
+   
    htmlContent = sanitizeHtml(htmlContent, {
       allowedTags: false,
       allowedAttributes: false,

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var stripJs = function(htmlContent) {
    }
 
    // Sanitize the HTML first:
+   var doctypeRegex = /<!DOCTYPE .*?>/i;
+   var doctypes = htmlContent.match(doctypeRegex);
    htmlContent = sanitizeHtml(htmlContent, {
       allowedTags: false,
       allowedAttributes: false,
@@ -16,6 +18,11 @@ var stripJs = function(htmlContent) {
          img: ['http', 'https', 'data', 'cid']
       }
    });
+   
+   // Preserve doctype
+   if (doctypes && doctypes.length) {
+     htmlContent = doctypes[0] + htmlContent
+   }
 
    var $ = cheerio.load(htmlContent);
 

--- a/test/input.html
+++ b/test/input.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
    <body>
       <script src="foo.js"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@ assert(stripJs('  foo bar  ') === '  foo bar  ');
 // Load an HTML file and strip out all JS, and remove whitespace from it
 // While preserving its doctype
 var inputHtml = fs.readFileSync('./test/input.html').toString();
-var processedHtml = stripJs(inputHtml);
+var processedHtml = stripJs(inputHtml, { preserveDoctypes: true });
 processedHtml = htmlclean(processedHtml);
 
 // and it shouldn't have any JS in it:

--- a/test/test.js
+++ b/test/test.js
@@ -13,13 +13,14 @@ assert(stripJs(undefined) === '');
 // Test non HTML strings with whitespace:
 assert(stripJs('  foo bar  ') === '  foo bar  ');
 
-// Load an HTML file and strip out all JS, and remove whitespace from it:
+// Load an HTML file and strip out all JS, and remove whitespace from it
+// While preserving its doctype
 var inputHtml = fs.readFileSync('./test/input.html').toString();
 var processedHtml = stripJs(inputHtml);
 processedHtml = htmlclean(processedHtml);
 
 // and it shouldn't have any JS in it:
-assert(processedHtml === '<html><body> <img src="image.gif" foo="bar"> ' +
+assert(processedHtml === '<!DOCTYPE html><html><body> <img src="image.gif" foo="bar"> ' +
    '<a target="_blank">Dangerous Link</a> <a href="http://www.google.com" ' +
    'target="_blank">Safe Link</a><p> This is some text in a p tag, but the p ' +
    'tag is not closed!</p></body></html>');
@@ -59,7 +60,5 @@ assert(stripJs('<img src="foo:bar">') ==
 // Scripts cannot be injected through links
 assert.equal(stripJs('<link rel="preload" href="https://adservice.google.com.sg/adsid/' +
   'integrator.js?domain=sourceforge.net" as="script">'), '');
-
-// TODO: More test cases?
 
 console.log('All tests pass.');


### PR DESCRIPTION
currently, doctypes are completely removed from documents, causing browsers to render the resulting document differently

this is due to a [problem with sanitize-html](https://github.com/punkave/sanitize-html/issues/131)